### PR TITLE
use is_serialized() instead of is_string()

### DIFF
--- a/src/WP_CLI/SearchReplacer.php
+++ b/src/WP_CLI/SearchReplacer.php
@@ -83,7 +83,7 @@ class SearchReplacer {
 				}
 			}
 
-			$unserialized = is_string( $data ) ? @unserialize( $data ) : false;
+			$unserialized = is_serialized( $data ) ? @unserialize( $data ) : false;
 			if ( false !== $unserialized ) {
 				$data = $this->run_recursively( $unserialized, true, $recursion_level + 1 );
 			} elseif ( is_array( $data ) ) {


### PR DESCRIPTION
Fixes #112 - serialization warnings in PHP 8.*
